### PR TITLE
Mark AdditionalDocumentReference in UblInvoice as array

### DIFF
--- a/src/UBL/Documents/UblInvoice.php
+++ b/src/UBL/Documents/UblInvoice.php
@@ -70,10 +70,11 @@ final class UblInvoice extends UblAbstractDocument
     #[SerializedName('ContractDocumentReference')]
     public ?DocumentReference $contractDocumentReference = null;
 
-    #[Type(DocumentReference::class)]
-    #[XmlElement(cdata: false, namespace: 'urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2')]
+    /** @var DocumentReference[] */
+    #[Type('array<easybill\eInvoicing\UBL\Models\DocumentReference>')]
     #[SerializedName('AdditionalDocumentReference')]
-    public ?DocumentReference $additionalDocumentReference = null;
+    #[XmlList(entry: 'AdditionalDocumentReference', inline: true, namespace: 'urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2')]
+    public array $additionalDocumentReference = [];
 
     #[Type(DocumentReference::class)]
     #[XmlElement(cdata: false, namespace: 'urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2')]


### PR DESCRIPTION
There is currently a bug in ubl invoice document which only allows one additional referenced document. This is plain wrong. 