### PR TITLE
0.2.1 - Add missing document types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # e-invoicing
-[![Generic badge](https://img.shields.io/badge/Version-0.2.0-important.svg)]()
+[![Generic badge](https://img.shields.io/badge/Version-0.2.1-important.svg)]()
 [![Generic badge](https://img.shields.io/badge/License-MIT-blue.svg)]()
 
 ## Introduction

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "easybill/e-invoicing",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "description": "A package to read and create the formats: factur-x, Peppol BIS Billing, XRechnung (CII/UBL)",
     "type": "library",
     "license": "MIT",

--- a/src/Enums/DocumentType.php
+++ b/src/Enums/DocumentType.php
@@ -7,6 +7,11 @@ namespace easybill\eInvoicing\Enums;
 enum DocumentType: int
 {
     /**
+     * Applicable for Additional document.
+     */
+    case VALIDATED_PRICE_TENDER = 50;
+
+    /**
      * Applicable for Invoice.
      */
     case REQUEST_FOR_PAYMENT = 71;
@@ -220,6 +225,11 @@ enum DocumentType: int
      * Applicable for Invoice.
      */
     case FREIGHT_INVOICE = 780;
+
+    /**
+     * Applicable for Additional document.
+     */
+    case RELATED_DOCUMENT = 916;
 
     /**
      * Applicable for Invoice.

--- a/tools/Generators/Input/DocumentTypes.csv
+++ b/tools/Generators/Input/DocumentTypes.csv
@@ -1,4 +1,5 @@
-﻿71;Request for payment;Invoice
+﻿50;Validated price tender;Additional document
+71;Request for payment;Invoice
 80;Debit note related to goods or services;Invoice
 81;Credit note related to goods or services;Credit Note
 82;Metered services invoice;Invoice
@@ -41,4 +42,5 @@
 633;Port charges documents;Invoice
 751;Invoice information for accounting purposes;Invoice
 780;Freight invoice;Invoice
+916;Related document;Additional document
 935;Customs invoice;Invoice


### PR DESCRIPTION
Added missing document types which are not present in the sheet 1001 of the EN16931 code list. The missing types are not to be used as the "main" type of the document but for the referenced documents / binary objects. 